### PR TITLE
네이버 지역 검색 API 구현

### DIFF
--- a/api/naverLocalSearch.go
+++ b/api/naverLocalSearch.go
@@ -11,6 +11,7 @@ type NaverLocalSearchHandler struct {
 	Service *services.LocalSearchService
 }
 
+//TODO: naverLocalSearch Cache 추가
 func NewNaverLocalSearchHandler(service *services.LocalSearchService) *NaverLocalSearchHandler {
 	return &NaverLocalSearchHandler{Service: service}
 }

--- a/api/naverLocalSearch.go
+++ b/api/naverLocalSearch.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/Todari/pin-to-gather-server/services"
+	"github.com/gin-gonic/gin"
+)
+
+type NaverLocalSearchHandler struct {
+	Service *services.LocalSearchService
+}
+
+func NewNaverLocalSearchHandler(service *services.LocalSearchService) *NaverLocalSearchHandler {
+	return &NaverLocalSearchHandler{Service: service}
+}
+
+func (h *NaverLocalSearchHandler) SearchLocal(c *gin.Context) {
+	query := c.Query("query")
+	if query == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "검색어를 입력해주세요"})
+		return
+	}
+
+	searchResult, err := h.Service.SearchLocal(query)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, searchResult)
+}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,10 @@ func main() {
     websocketService := services.NewWebSocketService()
     websocketHandler := api.NewWebSocketHandler(websocketService)
 
-    r := routes.SetupRouter(boardHandler, websocketHandler) // *gin.Engine 반환
+	naverLocalSearchService := services.NewLocalSearchService()
+	naverLocalSearchHandler := api.NewNaverLocalSearchHandler(naverLocalSearchService)
+
+    r := routes.SetupRouter(boardHandler, websocketHandler, naverLocalSearchHandler) // *gin.Engine 반환
 
     port := config.AppConfig.ServerPort
     log.Println("🚀 Server running on port:", port)

--- a/models/naverLocalSearch.go
+++ b/models/naverLocalSearch.go
@@ -1,0 +1,21 @@
+package models
+
+type NaverLocalSearchResponse struct {
+	LastBuildDate string `json:"lastBuildDate"`
+	Total         int    `json:"total"`
+	Start         int    `json:"start"`
+	Display       int    `json:"display"`
+	Items         []NaverLocalSearchItem `json:"items"`
+}
+
+type NaverLocalSearchItem struct {
+	Title       string `json:"title"`
+	Link        string `json:"link"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Telephone   string `json:"telephone"`
+	Address     string `json:"address"`
+	RoadAddress string `json:"roadAddress"`
+	MapX        string `json:"mapx"`
+	MapY        string `json:"mapy"`
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRouter(boardHandler *api.BoardHandler, websocketHandler *api.WebSocketHandler) *gin.Engine {
+func SetupRouter(boardHandler *api.BoardHandler, websocketHandler *api.WebSocketHandler, naverLocalSearchHandler *api.NaverLocalSearchHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS 설정 추가
@@ -25,6 +25,11 @@ func SetupRouter(boardHandler *api.BoardHandler, websocketHandler *api.WebSocket
 		boardRoutes.POST("", boardHandler.RegisterBoard)
 		boardRoutes.GET("/:uuid", boardHandler.GetBoard)
 		boardRoutes.PUT("/:uuid", boardHandler.UpdateBoardTitle)
+	}
+
+	naverLocalSearchRoutes := r.Group("/naver")
+	{
+		naverLocalSearchRoutes.GET("/local-search", naverLocalSearchHandler.SearchLocal)
 	}
 
 	wsRoutes := r.Group("/ws")

--- a/services/naverLocalSearch.go
+++ b/services/naverLocalSearch.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/Todari/pin-to-gather-server/models"
+)
+
+type LocalSearchService struct {
+	NaverClientID     string
+	NaverClientSecret string
+}
+
+func NewLocalSearchService() *LocalSearchService {
+	return &LocalSearchService{
+		NaverClientID:     os.Getenv("NAVER_CLIENT_ID"),
+		NaverClientSecret: os.Getenv("NAVER_CLIENT_SECRET"),
+	}
+}
+
+func (s *LocalSearchService) SearchLocal(query string) (models.NaverLocalSearchResponse, error) {
+	baseURL := "https://openapi.naver.com/v1/search/local.json"
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("display", "5")
+
+	req, err := http.NewRequest("GET", baseURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return models.NaverLocalSearchResponse{}, fmt.Errorf("요청 생성 실패: %w", err)
+	}
+
+	req.Header.Set("X-Naver-Client-Id", s.NaverClientID)
+	req.Header.Set("X-Naver-Client-Secret", s.NaverClientSecret)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return models.NaverLocalSearchResponse{}, fmt.Errorf("API 호출 실패: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return models.NaverLocalSearchResponse{}, fmt.Errorf("응답 읽기 실패: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return models.NaverLocalSearchResponse{}, fmt.Errorf("네이버 API 오류: %s", string(body))
+	}
+
+	var searchResult models.NaverLocalSearchResponse
+	if err := json.Unmarshal(body, &searchResult); err != nil {
+		return models.NaverLocalSearchResponse{}, fmt.Errorf("JSON 파싱 실패: %w", err)
+	}
+
+	return searchResult, nil
+}


### PR DESCRIPTION
## issue
- close #2

## 📄 구현 목적
기존에는 client에서 검색 API를 직접 호출했지만, API 키 보호를 위해서 백엔드에서 호출하는 방향으로 결정하였습니다.
또한, 서비스 사용 시 같은 지도를 보는 client끼리 동일한 검색 결과를 자주 볼 수 있을 것이라 판단했습니다.
client 호출을 하여 결과를 캐싱하면, 클라이언트가 늘어나는 대로 API의 호출 횟수가 증가하지만,
golang 서버에서 호출을 하여 캐싱한다면 다양한 client가 있어도 같은 결과를 제공할 수 있을 것이라 기대합니다.

방식 | API Key 보호 | 속도 | 서버 부하 | 추천 상황
-- | -- | -- | -- | --
Golang 백엔드 호출 | ✅ 안전 | ⭕ 보통 | 🔺 서버 부담 증가 | API Key 보호 & Rate Limit 관리 필요
Next.js API Routes | ✅ 안전 | ⭕ 보통 | 🔺 서버 부담 증가 | 서버리스 환경 (Vercel 등)에서 사용
클라이언트 직접 호출 | ❌ 위험 | ✅ 빠름 | ❌ 서버 부담 없음 | API Key 보호 필요 없고, CORS 허용된 경우

## 📄 구현 사항

- [x] naver 지역 검색 API 구현

## 🫡 참고사항

검색 결과를 caching하는 로직을 추가하려고 하였지만, 필요한 기능들을 먼저 구현한 뒤,
서버 부하 문제에도 불구하고 필요성을 느낀다면 추후에 적용하는 것이 좋을 것이라고 판단했습니다.
